### PR TITLE
Option to Specify Order in which Keys should be Imported

### DIFF
--- a/Classes/NSObject+RZImport.m
+++ b/Classes/NSObject+RZImport.m
@@ -332,15 +332,28 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
     BOOL canOverrideImports = [self respondsToSelector:@selector( rzi_shouldImportValue:forKey: )];
     
     NSSet *ignoredKeys = [[self class] rzi_cachedIgnoredKeys];
-    
-    [dict enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-    
+    NSOrderedSet *orderedKeys = [[self class] rzi_cachedOrderedKeys];
+
+    NSArray *dictKeys = dict.allKeys;
+
+    if ( orderedKeys.count > 0 ) {
+        dictKeys = [dictKeys sortedArrayUsingComparator:^NSComparisonResult(id obj1, id obj2) {
+            NSUInteger idx1 = [orderedKeys indexOfObject:obj1];
+            NSUInteger idx2 = [orderedKeys indexOfObject:obj2];
+
+            return [@(idx1) compare:@(idx2)];
+        }];
+    }
+
+    [dictKeys enumerateObjectsUsingBlock:^(NSString *key, NSUInteger idx, BOOL *stop) {
+        id value = dict[key];
+
         if ( canOverrideImports && ![ignoredKeys containsObject:key] ) {
             if ( ![(id<RZImportable>)self rzi_shouldImportValue:value forKey:key] ) {
                 return;
             }
         }
-        
+
         [self rzi_importValue:value forKey:key withMappings:mappings ignoredKeys:ignoredKeys];
     }];
 }
@@ -465,6 +478,27 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
         }
     }];
     return nestedKeys;
+}
+
++ (NSOrderedSet *)rzi_cachedOrderedKeys
+{
+    static void * kRZIOrderedKeysAssocKey = &kRZIOrderedKeysAssocKey;
+    __block NSOrderedSet *orderedKeys = nil;
+    [self rzi_performBlockAtomicallyAndWait:YES block:^{
+        orderedKeys = objc_getAssociatedObject(self, kRZIOrderedKeysAssocKey);
+        if ( orderedKeys == nil ) {
+            if ( [self respondsToSelector:@selector( rzi_orderedKeys )] ) {
+                Class <RZImportable> thisClass = self;
+                orderedKeys = [NSOrderedSet orderedSetWithArray:[thisClass rzi_orderedKeys]];
+            }
+            else {
+                // !!!: empty set so cache does not fault again
+                orderedKeys = [NSOrderedSet orderedSet];
+            }
+            objc_setAssociatedObject(self, kRZIOrderedKeysAssocKey, orderedKeys, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        }
+    }];
+    return orderedKeys;
 }
 
 // !!!: this method is not threadsafe

--- a/Classes/RZImportable.h
+++ b/Classes/RZImportable.h
@@ -65,6 +65,15 @@
 + (NSArray *)rzi_nestedObjectKeys;
 
 /**
+ *  Implement to provide the order in which keys should be imported.
+ *  When performing an import, keys in this array will be imported first, and in the order specified.
+ *  Keys not including in this array will be imported in an arbitrary order.
+ *
+ *  @return An array of NSString objects representing keys in the order in which they should be imported.
+ */
++ (NSArray *)rzi_orderedKeys;
+
+/**
  *  Implement to provide a custom date format string for a particular key or keys.
  *  Will only be called if the inferred property is an NSDate type and the dict value is a string.
  *


### PR DESCRIPTION
Sometimes models need to import keys in a specific order. For example, if the custom import of one key is based on the value of another key.

**P.S. I opened this against master since there isn't a development branch.**