### PR TITLE
import bool primitive

### DIFF
--- a/Classes/NSObject+RZImport.m
+++ b/Classes/NSObject+RZImport.m
@@ -638,6 +638,7 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
                 switch (propDescriptor.dataType) {
                         
                     case RZImportDataTypeNSNumber:
+                    case RZImportDataTypeBoolean:
                     case RZImportDataTypePrimitive:
                         convertedValue = value;
                         break;
@@ -652,10 +653,6 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
                     }
                         break;
                         
-                    case RZImportDataTypeBoolean:
-                        convertedValue = value;
-                        break;
-
                     default:
                         break;
                 }
@@ -679,6 +676,10 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
                         convertedValue = value;
                         break;
                         
+                    case RZImportDataTypeBoolean:
+                        convertedValue = @([value boolValue]);
+                        break;
+
                     case RZImportDataTypeNSDate: {
                         // Check for a date format from the object. If not provided, use ISO-8601.
                         __block NSDate *date = nil;
@@ -703,14 +704,7 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
                         
                     }
                         break;
-                    case RZImportDataTypeBoolean: {
-                        __block NSNumber *boolNumber = nil;
-                        [[self class] rzi_performBlockAtomicallyAndWait:YES block:^{
-                            boolNumber = [NSNumber numberWithBool:[value boolValue]];
-                        }];
-                        convertedValue = boolNumber;
-                    }
-                        break;
+
                     default:
                         break;
                 }

--- a/Classes/NSObject+RZImport.m
+++ b/Classes/NSObject+RZImport.m
@@ -100,7 +100,11 @@ static RZIPropertyInfo *rzi_propertyInfoForProperty( NSString *propertyName, Cla
             }
         }
             break;
-            
+
+        case _C_BOOL:
+            propertyInfo.dataType = RZImportDataTypeBoolean;
+            break;
+
             // Primitive type
         case _C_CHR:
         case _C_UCHR:
@@ -114,7 +118,6 @@ static RZIPropertyInfo *rzi_propertyInfoForProperty( NSString *propertyName, Cla
         case _C_ULNG_LNG:
         case _C_FLT:
         case _C_DBL:
-        case _C_BOOL:
             propertyInfo.dataType = RZImportDataTypePrimitive;
             break;
             
@@ -649,6 +652,10 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
                     }
                         break;
                         
+                    case RZImportDataTypeBoolean:
+                        convertedValue = value;
+                        break;
+
                     default:
                         break;
                 }
@@ -696,7 +703,14 @@ RZImportDataType rzi_dataTypeFromClass(Class objClass)
                         
                     }
                         break;
-                        
+                    case RZImportDataTypeBoolean: {
+                        __block NSNumber *boolNumber = nil;
+                        [[self class] rzi_performBlockAtomicallyAndWait:YES block:^{
+                            boolNumber = [NSNumber numberWithBool:[value boolValue]];
+                        }];
+                        convertedValue = boolNumber;
+                    }
+                        break;
                     default:
                         break;
                 }

--- a/Classes/Private/NSObject+RZImport_Private.h
+++ b/Classes/Private/NSObject+RZImport_Private.h
@@ -50,6 +50,7 @@ typedef NS_ENUM(NSInteger, RZImportDataType)
     RZImportDataTypeNSDictionary,
     RZImportDataTypeNSArray,
     RZImportDataTypeNSSet,
+    RZImportDataTypeBoolean,
     RZImportDataTypeOtherObject
 };
 

--- a/Tests/Tests/Model/Person.h
+++ b/Tests/Tests/Model/Person.h
@@ -15,10 +15,9 @@
 
 @property (nonatomic, copy) NSString *firstName;
 @property (nonatomic, copy) NSString *lastName;
-
 @property (nonatomic, copy) NSString *colorPref;
-
 @property (nonatomic, strong) Address *address;
-
 @property (nonatomic, strong) Job *job;
+@property (nonatomic, assign) bool deceased;
+
 @end

--- a/Tests/Tests/RZImportTests.m
+++ b/Tests/Tests/RZImportTests.m
@@ -397,6 +397,12 @@ extern uint64_t dispatch_benchmark(size_t count, void (^block)(void));
     XCTAssert(![self test_oneBool:@0   ]);
     XCTAssert(![self test_oneBool:@false]);
     XCTAssert(![self test_oneBool:[NSNull null]]);
+    XCTAssert(![self test_oneBool:@"0"      ]);
+    XCTAssert(![self test_oneBool:@" 0"     ]);
+    XCTAssert(![self test_oneBool:@" 0 "    ]);
+    XCTAssert(![self test_oneBool:@" 0.0 "  ]);
+    XCTAssert(![self test_oneBool:@"NOT a number means 'false' "  ]);
+
     XCTAssert([self test_oneBool:@"yes" ]);
     XCTAssert([self test_oneBool:@"YES" ]);
     XCTAssert([self test_oneBool:@"y"   ]);
@@ -405,6 +411,10 @@ extern uint64_t dispatch_benchmark(size_t count, void (^block)(void));
     XCTAssert([self test_oneBool:@-1    ]);
     XCTAssert([self test_oneBool:@42    ]);
     XCTAssert([self test_oneBool:@true  ]);
+    XCTAssert([self test_oneBool:@"1"   ]);
+    XCTAssert([self test_oneBool:@" 1"  ]);
+    XCTAssert([self test_oneBool:@" 1 " ]);
+    XCTAssert([self test_oneBool:@"42"  ]);
 // clang-format on
 }
 @end

--- a/Tests/Tests/RZImportTests.m
+++ b/Tests/Tests/RZImportTests.m
@@ -15,6 +15,8 @@
 #import "Job.h"
 #import "TestDataStore.h"
 
+@import Foundation;
+
 extern uint64_t dispatch_benchmark(size_t count, void (^block)(void));
 
 @interface RZImportTests : XCTestCase
@@ -379,6 +381,30 @@ extern uint64_t dispatch_benchmark(size_t count, void (^block)(void));
     XCTAssertEqualObjects(guysJob.companyName, companyName, @"Failed to import Company Name");
     XCTAssertEqualObjects(guysJob.title, title, @"Failed to import title");
 }
-    
 
+- (BOOL)test_oneBool:(id)value
+{
+    return [Person rzi_objectFromDictionary:@{ @"deceased" : value }].deceased;
+}
+
+- (void)test_booleanImport
+{
+// clang-format off
+    XCTAssert(![self test_oneBool:@"no"     ]);
+    XCTAssert(![self test_oneBool:@"NO"     ]);
+    XCTAssert(![self test_oneBool:@"n" ]);
+    XCTAssert(![self test_oneBool:@"N" ]);
+    XCTAssert(![self test_oneBool:@0   ]);
+    XCTAssert(![self test_oneBool:@false]);
+    XCTAssert(![self test_oneBool:[NSNull null]]);
+    XCTAssert([self test_oneBool:@"yes" ]);
+    XCTAssert([self test_oneBool:@"YES" ]);
+    XCTAssert([self test_oneBool:@"y"   ]);
+    XCTAssert([self test_oneBool:@"Y"   ]);
+    XCTAssert([self test_oneBool:@1     ]);
+    XCTAssert([self test_oneBool:@-1    ]);
+    XCTAssert([self test_oneBool:@42    ]);
+    XCTAssert([self test_oneBool:@true  ]);
+// clang-format on
+}
 @end


### PR DESCRIPTION
When importing to a boolean field, convert incoming strings and numbers to appropriate bool representations.

Incoming strings are converted via `-[NSString boolValue]`, which currently is documented as:
> This property is YES on encountering one of "Y", "y", "T", "t", or a digit 1-9—the method ignores any trailing characters. This property is NO if the receiver doesn’t begin with a valid decimal text representation of a number.

Incoming numbers are converted with `-[NSNumber boolValue]`, which currently is documented as:
> A 0 value always means NO, and any nonzero value is interpreted as YES.